### PR TITLE
Providing full support for ACL, including role-based ACL

### DIFF
--- a/addon/adapters/parse.js
+++ b/addon/adapters/parse.js
@@ -105,7 +105,7 @@ export default DS.RESTAdapter.extend({
   },
 
   ajaxError(jqXHR, responseText, errorThrown) {
-    if (jqXHR && jqXHR.responseJSON.error === 'invalid session token') {
+    if (jqXHR.responseJSON && jqXHR.responseJSON.error === 'invalid session token') {
       // invalid session
       var session = this.container.lookup('service:session');
       session.resetSession();

--- a/addon/adapters/parse.js
+++ b/addon/adapters/parse.js
@@ -152,7 +152,12 @@ export default DS.RESTAdapter.extend({
   },
 
   parseClassName(key) {
-    return Ember.String.capitalize(key);
+    // 'one-name' => 'OneName'
+    return key.split('-')
+    .map(function(s){
+      return Ember.String.capitalize(s);
+    })
+    .join('');
   },
 
   /**

--- a/addon/adapters/parse.js
+++ b/addon/adapters/parse.js
@@ -105,7 +105,7 @@ export default DS.RESTAdapter.extend({
   },
 
   ajaxError(jqXHR, responseText, errorThrown) {
-    if (jqXHR.responseJSON.error === 'invalid session token') {
+    if (jqXHR && jqXHR.responseJSON.error === 'invalid session token') {
       // invalid session
       var session = this.container.lookup('service:session');
       session.resetSession();

--- a/addon/adapters/parse.js
+++ b/addon/adapters/parse.js
@@ -153,11 +153,7 @@ export default DS.RESTAdapter.extend({
 
   parseClassName(key) {
     // 'one-name' => 'OneName'
-    return key.split('-')
-    .map(function(s){
-      return Ember.String.capitalize(s);
-    })
-    .join('');
+    return Ember.String.capitalize(Ember.String.camelize(key));
   },
 
   /**

--- a/addon/initializers/parse.js
+++ b/addon/initializers/parse.js
@@ -1,10 +1,25 @@
 import ParseSession from '../services/session';
 
+import Adapter from '../adapters/parse';
+import Serializer from '../serializers/parse';
+import DateTransform from '../transforms/date';
+import FileTransform from '../transforms/file';
+import GeopointTransform from '../transforms/geopoint';
+import ParseUser from '../models/parse-user';
+
 export function initialize(container) {
   container.register('service:session', ParseSession);
   container.injection('route', 'session', 'service:session');
   container.injection('controller', 'session', 'service:session');
   container.injection('component', 'session', 'service:session');
+
+  container.register('adapter:-parse', Adapter);
+  container.register('serializer:-parse', Serializer);
+  container.register('transform:parse-date', DateTransform);
+  container.register('transform:parse-file', FileTransform);
+  container.register('transform:parse-geo-point', GeopointTransform);
+  container.register('model:parse-user', ParseUser);
+
 }
 
 export default {

--- a/addon/serializers/parse.js
+++ b/addon/serializers/parse.js
@@ -139,6 +139,33 @@ export default DS.RESTSerializer.extend({
     }
   },
 
+  //In order to send the following ACL through REST API
+  // {
+  //   "8TOXdXf3tz": {
+  //     "read": true
+  //     "write": true
+  //   },
+  //   "role:Whole_Company": {
+  //     "write": true
+  //   },
+  //   "*": {
+  //     "read": true
+  //   }
+  // }
+  // please define theObject.ParseACL.raw = [
+  //   {
+  //     "id" : "8TOXdXf3tz",
+  //     "permission" : {"read": true, "write": true}
+  //   },
+  //   {
+  //     "id" : "role:Whole_Company",
+  //     "permission" : {"write": true}
+  //   },
+  //   {
+  //     "id" : "*",
+  //     "permission" : {"read": true}
+  //   }
+  // ]
   serializeIntoHash(hash, type, snapshot, options) {
     var ParseACL = snapshot.record.get('ParseACL');
 
@@ -148,16 +175,22 @@ export default DS.RESTSerializer.extend({
 
       if (ParseACL.owner) {
         policy[ParseACL.owner] = {};
+        if (ParseACL.permissions) {
+          policy[ParseACL.owner] = ParseACL.permissions;
+        } else {
+          policy[ParseACL.owner] = {
+            read: true,
+            write: true
+          };
+        }
       }
 
-      if (ParseACL.permissions) {
-        policy[ParseACL.owner] = ParseACL.permissions;
-      } else {
-        policy[ParseACL.owner] = {
-          read: true,
-          write: true
-        };
+      if (ParseACL.raw){
+        ParseACL.raw.forEach(function(item) {
+          policy[item.id] = item.permission;
+        });
       }
+
       hash.ACL = policy;
     }
 

--- a/addon/serializers/parse.js
+++ b/addon/serializers/parse.js
@@ -221,7 +221,7 @@ export default DS.RESTSerializer.extend({
         payloadKey = this.keyForRelationship(key, "hasMany");
       }
 
-      var relationshipType = snapshot.type.determineRelationshipType(relationship);
+      var relationshipType = snapshot.type.determineRelationshipType(relationship, this.store);
 
       if (relationshipType === 'manyToNone' || relationshipType === 'manyToMany' || relationshipType === 'manyToOne') {
         var objects = [],
@@ -236,7 +236,7 @@ export default DS.RESTSerializer.extend({
 
           objects.push({
             __type: 'Pointer',
-            className: this.parseClassName(snapshot.type.typeForRelationship(key).modelName),
+            className: this.parseClassName(snapshot.type.typeForRelationship(key, this.store).modelName),
             objectId: objectsBeforeUpdate.list[0].id
           });
         }

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -40,6 +40,24 @@ export default Ember.Controller.extend({
         thingObj.ParseACL = {
           owner: this.get('session.userId')
         };
+
+        //Or try this
+        // thingObj.ParseACL = {
+        //   raw : [
+        //     {
+        //       "id" : this.get('session.userId'),
+        //       "permission" : {"read": true, "write": true}
+        //     },
+        //     {
+        //       "id" : "role:NameOfTheRole",
+        //       "permission" : {"write": true}
+        //     },
+        //     {
+        //       "id" : "*",
+        //       "permission" : {"read": true}
+        //     }
+        //   ]
+        // };
       }
 
       var thing = this.store.createRecord('thing', thingObj);


### PR DESCRIPTION
In the serializer, I use a straightforward way to add ACL into an parse object. It provides the low level management over the ACL, including adding role-based control and public readability control.

In order to send the following ACL through REST API

```
  {
    "8TOXdXf3tz": {
      "read": true
      "write": true
    },
    "role:Whole_Company": {
      "write": true
    },
    "*": {
      "read": true
    }
  }
```

Programmers need write this 

```
    objectToSave.ParseACL = {
        raw : [
          {
            "id" : this.get('session.userId'),
            "permission" : {"read": true, "write": true}
          },
          {
            "id" : "role:Whole_Company",
            "permission" : {"write": true}
          },
          {
            "id" : "*",
            "permission" : {"read": true}
          }
        ]
      };
```

Any comment will be welcomed. I'll improve this according to your suggestions. 
I'm currently developing a dashboard-like website based ember.js and parse
